### PR TITLE
[이든] 자판기 STEP 2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,6 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 
 import VendingMachine from './pages/VendingMachine';
 import Wallet from './pages/Wallet';
-
 import Button from './components/Button';
 
 export default function App() {

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-function Button({ className, icon, disabled, onClick }) {
+export default function Button({ className, icon, disabled, onClick }) {
   return (
     <StyledButton disabled={disabled} className={className} onClick={onClick}>
       {icon}
@@ -27,5 +27,3 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
 };
-
-export default Button;

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -1,44 +1,24 @@
-import React, { useState } from 'react';
+/* eslint-disable react/require-default-props */
+import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 import Button from './Button';
 
-function Input() {
-  const [price, setPrice] = useState(0);
-  const [content, setContent] = useState(0);
-
-  const handleChangeInput = ({ currentTarget }) => {
-    setContent(currentTarget.textContent);
-  };
-
-  const handleClickSave = () => {
-    if (Number.isNaN(Number(content))) {
-      window.alert('숫자만 입력 가능합니다.');
-      return;
-    }
-
-    if (Number(content) < 10) {
-      window.alert('10원 이상 추가해야합니다.');
-      return;
-    }
-
-    // Todo : 지갑에 요금의 개수가 없거나 지갑 전체 요금보다 큰 경우 예외처리
-    setPrice(content);
-  };
-
+export default function Input({ price, onChangeInput, onClickSave }) {
   return (
     <>
       <StyledInputContainer>
         <StyledInput
           contentEditable="true"
-          onInput={handleChangeInput}
+          onInput={onChangeInput}
           placeholder="0원"
           suppressContentEditableWarning
         >
           {price > 0 && `${price}원`}
         </StyledInput>
       </StyledInputContainer>
-      <Button icon="추가" onClick={handleClickSave} />
+      <Button icon="추가" onClick={onClickSave} />
     </>
   );
 }
@@ -67,4 +47,8 @@ const StyledInput = styled.div`
   }
 `;
 
-export default Input;
+Input.propTypes = {
+  price: PropTypes.number,
+  onChangeInput: PropTypes.func,
+  onClickSave: PropTypes.func,
+};

--- a/src/components/ProgressBoard.jsx
+++ b/src/components/ProgressBoard.jsx
@@ -1,0 +1,17 @@
+/* eslint-disable react/forbid-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function ProgressBoard({ progressMsg }) {
+  return (
+    <ul>
+      {progressMsg.map((msg) => (
+        <li key={`msg-${msg}`}>{msg}</li>
+      ))}
+    </ul>
+  );
+}
+
+ProgressBoard.propTypes = {
+  progressMsg: PropTypes.array.isRequired,
+};

--- a/src/components/WalletItem.jsx
+++ b/src/components/WalletItem.jsx
@@ -1,0 +1,21 @@
+/* eslint-disable react/require-default-props */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Button from './Button';
+
+export default function WalletItem({ icon, won, num, onClick }) {
+  return (
+    <li>
+      <Button icon={icon} onClick={() => onClick(won)} />
+      <span>{`${num}개`}</span>
+    </li>
+  );
+}
+
+WalletItem.propTypes = {
+  icon: PropTypes.string.isRequired,
+  won: PropTypes.number,
+  num: PropTypes.number,
+  onClick: PropTypes.func,
+};

--- a/src/context/MoneyProvider.jsx
+++ b/src/context/MoneyProvider.jsx
@@ -21,11 +21,6 @@ export default function MoneyProvider({ children }) {
     const targetMoney = moneyState.find(({ won }) => won === targetWon);
     const filteredMoney = moneyState.filter(({ won }) => won !== targetWon);
 
-    if (targetMoney.num < 1) {
-      window.alert('돈이 부족합니다.');
-      return;
-    }
-
     setMoneyState(
       [
         ...filteredMoney,

--- a/src/context/MoneyProvider.jsx
+++ b/src/context/MoneyProvider.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/require-default-props */
+import React, { useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+export const MoneyContext = React.createContext();
+
+export default function MoneyProvider({ children }) {
+  const money = [
+    { won: 10, num: 0 },
+    { won: 50, num: 1 },
+    { won: 100, num: 5 },
+    { won: 500, num: 5 },
+    { won: 1000, num: 2 },
+    { won: 5000, num: 2 },
+    { won: 10000, num: 1 },
+  ];
+
+  const [moneyState, setMoneyState] = useState(money);
+
+  const decreaseMoney = (targetWon) => {
+    const targetMoney = moneyState.find(({ won }) => won === targetWon);
+    const filteredMoney = moneyState.filter(({ won }) => won !== targetWon);
+
+    if (targetMoney.num < 1) {
+      window.alert('돈이 부족합니다.');
+      return;
+    }
+
+    setMoneyState(
+      [
+        ...filteredMoney,
+        { won: targetMoney.won, num: targetMoney.num - 1 },
+      ].sort((aMoney, bMoney) => aMoney.won - bMoney.won)
+    );
+  };
+
+  const value = useMemo(
+    () => ({
+      moneyState,
+      decreaseMoney,
+    }),
+    [moneyState, decreaseMoney]
+  );
+
+  return (
+    <MoneyContext.Provider value={value}>{children}</MoneyContext.Provider>
+  );
+}
+
+MoneyProvider.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element),
+  ]),
+};

--- a/src/context/PriceProvider.jsx
+++ b/src/context/PriceProvider.jsx
@@ -1,0 +1,48 @@
+/* eslint-disable react/require-default-props */
+import React, { useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+export const PriceContext = React.createContext();
+
+export default function PriceProvider({ children }) {
+  const [inputPrice, setInputPrice] = useState(0);
+  const [progressMsg, setProgressMsg] = useState([]);
+  const [remainMoney, setRemainMoney] = useState(0);
+
+  const updatePrice = (won) => {
+    setInputPrice(won);
+    setProgressMsg([...progressMsg, `${won}원이 투입되었습니다.`]);
+  };
+
+  const value = useMemo(
+    () => ({
+      inputPrice,
+      setInputPrice,
+      progressMsg,
+      setProgressMsg,
+      remainMoney,
+      setRemainMoney,
+      updatePrice,
+    }),
+    [
+      inputPrice,
+      setInputPrice,
+      progressMsg,
+      setProgressMsg,
+      remainMoney,
+      setRemainMoney,
+      updatePrice,
+    ]
+  );
+
+  return (
+    <PriceContext.Provider value={value}>{children}</PriceContext.Provider>
+  );
+}
+
+PriceProvider.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element),
+  ]),
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,10 +3,13 @@ import ReactDOM from 'react-dom/client';
 
 import 'reset-css';
 import App from './App';
+import MoneyProvider from './context/MoneyProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <MoneyProvider>
+      <App />
+    </MoneyProvider>
   </React.StrictMode>
 );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,12 +4,15 @@ import ReactDOM from 'react-dom/client';
 import 'reset-css';
 import App from './App';
 import MoneyProvider from './context/MoneyProvider';
+import PriceProvider from './context/PriceProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <MoneyProvider>
-      <App />
-    </MoneyProvider>
+    <PriceProvider>
+      <MoneyProvider>
+        <App />
+      </MoneyProvider>
+    </PriceProvider>
   </React.StrictMode>
 );

--- a/src/pages/VendingMachine.jsx
+++ b/src/pages/VendingMachine.jsx
@@ -1,5 +1,53 @@
 import React from 'react';
+import styled from 'styled-components';
+
+import { items } from '../store/store';
+import Button from '../components/Button';
+import AvailableButton from '../components/AvailableButton';
+import Input from '../components/Input';
 
 export default function VendingMachine() {
-  return <h1>자판기 페이지</h1>;
+  return (
+    <StyledContainer>
+      <StyledItems>
+        {items.map(({ title, price }) => (
+          <StyledItem key={`vm-item-${title}`}>
+            <AvailableButton icon={title} />
+            <StyledPrice>{price}</StyledPrice>
+          </StyledItem>
+        ))}
+      </StyledItems>
+      <StyledController>
+        <Input />
+        <Button icon="반환" />
+        <div>현황판</div>
+      </StyledController>
+    </StyledContainer>
+  );
 }
+const CONTAINER_SIZE = 500;
+
+const StyledContainer = styled.div`
+  display: flex;
+`;
+
+const StyledItems = styled.ul`
+  display: flex;
+  width: ${CONTAINER_SIZE}px;
+  flex-wrap: wrap;
+`;
+
+const StyledItem = styled.li`
+  width: ${CONTAINER_SIZE / 4}px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledController = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledPrice = styled.span`
+  text-align: center;
+`;

--- a/src/pages/VendingMachine.jsx
+++ b/src/pages/VendingMachine.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-import { items } from '../store/store';
+import items from '../store/store';
 import Button from '../components/Button';
 import AvailableButton from '../components/AvailableButton';
 import Input from '../components/Input';

--- a/src/pages/VendingMachine.jsx
+++ b/src/pages/VendingMachine.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { items } from '../store/store';
@@ -7,18 +7,47 @@ import AvailableButton from '../components/AvailableButton';
 import Input from '../components/Input';
 
 export default function VendingMachine() {
+  const [inputPrice, setPrice] = useState(0);
+  const [content, setContent] = useState(0);
+
+  const handleChangeInput = ({ currentTarget }) => {
+    setContent(currentTarget.textContent);
+  };
+
+  const handleClickSave = () => {
+    if (Number.isNaN(Number(content))) {
+      window.alert('숫자만 입력 가능합니다.');
+      return;
+    }
+
+    if (Number(content) < 10) {
+      window.alert('10원 이상 추가해야합니다.');
+      return;
+    }
+
+    // Todo : 지갑에 요금의 개수가 없거나 지갑 전체 요금보다 큰 경우 예외처리
+    setPrice(Number(content));
+  };
   return (
     <StyledContainer>
       <StyledItems>
         {items.map(({ title, price }) => (
           <StyledItem key={`vm-item-${title}`}>
-            <AvailableButton icon={title} />
+            <AvailableButton
+              icon={title}
+              isAvailabe={inputPrice >= price}
+              disabled={!(inputPrice >= price)}
+            />
             <StyledPrice>{price}</StyledPrice>
           </StyledItem>
         ))}
       </StyledItems>
       <StyledController>
-        <Input />
+        <Input
+          price={inputPrice}
+          onChangeInput={handleChangeInput}
+          onClickSave={handleClickSave}
+        />
         <Button icon="반환" />
         <div>현황판</div>
       </StyledController>

--- a/src/pages/VendingMachine.jsx
+++ b/src/pages/VendingMachine.jsx
@@ -5,10 +5,13 @@ import { items } from '../store/store';
 import Button from '../components/Button';
 import AvailableButton from '../components/AvailableButton';
 import Input from '../components/Input';
+import ProgressBoard from '../components/ProgressBoard';
 
 export default function VendingMachine() {
   const [inputPrice, setPrice] = useState(0);
   const [content, setContent] = useState(0);
+  const [progressMsg, setProgressMsg] = useState([]);
+  const [remainMoney, setRemainMoney] = useState(null);
 
   const handleChangeInput = ({ currentTarget }) => {
     setContent(currentTarget.textContent);
@@ -26,7 +29,25 @@ export default function VendingMachine() {
     }
 
     // Todo : 지갑에 요금의 개수가 없거나 지갑 전체 요금보다 큰 경우 예외처리
-    setPrice(Number(content));
+    const currentPrice = Number(content);
+    setPrice(currentPrice);
+    setRemainMoney(remainMoney + currentPrice);
+    setProgressMsg([...progressMsg, `${currentPrice}원이 투입되었습니다.`]);
+  };
+
+  const handleSelectItem = (title, price) => {
+    const currentRemainMoney = remainMoney - price;
+    if (currentRemainMoney < 0 && remainMoney !== null) {
+      window.alert('요금을 초과하였습니다.');
+      return;
+    }
+
+    setRemainMoney(currentRemainMoney);
+    setProgressMsg([...progressMsg, `${title}가 선택되었습니다.`]);
+  };
+
+  const handleClickReturnRemain = () => {
+    setProgressMsg([...progressMsg, `잔돈 ${remainMoney}원이 반환됩니다.`]);
   };
   return (
     <StyledContainer>
@@ -35,8 +56,9 @@ export default function VendingMachine() {
           <StyledItem key={`vm-item-${title}`}>
             <AvailableButton
               icon={title}
-              isAvailabe={inputPrice >= price}
-              disabled={!(inputPrice >= price)}
+              isAvailabe={remainMoney >= price}
+              disabled={!(remainMoney >= price)}
+              onClick={() => handleSelectItem(title, price)}
             />
             <StyledPrice>{price}</StyledPrice>
           </StyledItem>
@@ -48,8 +70,8 @@ export default function VendingMachine() {
           onChangeInput={handleChangeInput}
           onClickSave={handleClickSave}
         />
-        <Button icon="반환" />
-        <div>현황판</div>
+        <Button icon="반환" onClick={handleClickReturnRemain} />
+        <ProgressBoard progressMsg={progressMsg} />
       </StyledController>
     </StyledContainer>
   );

--- a/src/pages/VendingMachine.jsx
+++ b/src/pages/VendingMachine.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import styled from 'styled-components';
 
 import items from '../store/store';
@@ -6,12 +6,18 @@ import Button from '../components/Button';
 import AvailableButton from '../components/AvailableButton';
 import Input from '../components/Input';
 import ProgressBoard from '../components/ProgressBoard';
+import { PriceContext } from '../context/PriceProvider';
 
 export default function VendingMachine() {
-  const [inputPrice, setPrice] = useState(0);
+  const {
+    inputPrice,
+    setInputPrice,
+    progressMsg,
+    setProgressMsg,
+    remainMoney,
+    setRemainMoney,
+  } = useContext(PriceContext);
   const [content, setContent] = useState(0);
-  const [progressMsg, setProgressMsg] = useState([]);
-  const [remainMoney, setRemainMoney] = useState(null);
 
   const handleChangeInput = ({ currentTarget }) => {
     setContent(currentTarget.textContent);
@@ -30,7 +36,7 @@ export default function VendingMachine() {
 
     // Todo : 지갑에 요금의 개수가 없거나 지갑 전체 요금보다 큰 경우 예외처리
     const currentPrice = Number(content);
-    setPrice(currentPrice);
+    setInputPrice(currentPrice);
     setRemainMoney(remainMoney + currentPrice);
     setProgressMsg([...progressMsg, `${currentPrice}원이 투입되었습니다.`]);
   };
@@ -49,6 +55,7 @@ export default function VendingMachine() {
   const handleClickReturnRemain = () => {
     setProgressMsg([...progressMsg, `잔돈 ${remainMoney}원이 반환됩니다.`]);
   };
+
   return (
     <StyledContainer>
       <StyledItems>

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -9,7 +9,12 @@ export default function Wallet() {
   const { setInputPrice, updatePrice, remainMoney, setRemainMoney } =
     useContext(PriceContext);
 
-  const handleClickWon = (won) => {
+  const handleClickWon = (won, num) => {
+    if (num < 1) {
+      window.alert('돈이 부족합니다.');
+      return;
+    }
+
     decreaseMoney(won);
     setInputPrice(won);
     updatePrice(won);
@@ -25,7 +30,7 @@ export default function Wallet() {
             icon={`${won}원 `}
             won={won}
             num={num}
-            onClick={() => handleClickWon(won)}
+            onClick={() => handleClickWon(won, num)}
           />
         ))}
       </ul>

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -1,28 +1,31 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import WalletItem from '../components/WalletItem';
-import { money } from '../store/store';
+import { MoneyContext } from '../context/MoneyProvider';
 
 export default function Wallet() {
-  const handleClickWon = () => {
+  const { moneyState, decreaseMoney } = useContext(MoneyContext);
+
+  const handleClickWon = (won) => {
+    decreaseMoney(won);
     // Todo : store의 setPrice(won)
   };
 
   return (
     <>
       <ul>
-        {money.map(({ won, num }) => (
+        {moneyState.map(({ won, num }) => (
           <WalletItem
             key={`money-${won}`}
             icon={`${won}원 `}
             won={won}
             num={num}
-            onClick={handleClickWon}
+            onClick={() => handleClickWon(won)}
           />
         ))}
       </ul>
       <span>
-        {`${`${money
+        {`${`${moneyState
           .map(({ won, num }) => won * num)
           .reduce((aMoney, bMoney) => aMoney + bMoney)}`
           .split('')

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -2,13 +2,18 @@ import React, { useContext } from 'react';
 
 import WalletItem from '../components/WalletItem';
 import { MoneyContext } from '../context/MoneyProvider';
+import { PriceContext } from '../context/PriceProvider';
 
 export default function Wallet() {
   const { moneyState, decreaseMoney } = useContext(MoneyContext);
+  const { setInputPrice, updatePrice, remainMoney, setRemainMoney } =
+    useContext(PriceContext);
 
   const handleClickWon = (won) => {
     decreaseMoney(won);
-    // Todo : store의 setPrice(won)
+    setInputPrice(won);
+    updatePrice(won);
+    setRemainMoney(remainMoney + won);
   };
 
   return (

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import WalletItem from '../components/WalletItem';
-import money from '../store/store';
+import { money } from '../store/store';
 
 export default function Wallet() {
   const handleClickWon = () => {

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -1,5 +1,41 @@
 import React from 'react';
 
+import WalletItem from '../components/WalletItem';
+import money from '../store/store';
+
 export default function Wallet() {
-  return <h1>지갑 페이지</h1>;
+  const handleClickWon = () => {
+    // Todo : store의 setPrice(won)
+  };
+
+  return (
+    <>
+      <ul>
+        {money.map(({ won, num }) => (
+          <WalletItem
+            key={`money-${won}`}
+            icon={`${won}원 `}
+            won={won}
+            num={num}
+            onClick={handleClickWon}
+          />
+        ))}
+      </ul>
+      <span>
+        {`${`${money
+          .map(({ won, num }) => won * num)
+          .reduce((aMoney, bMoney) => aMoney + bMoney)}`
+          .split('')
+          .reverse()
+          .map((element, index, array) => {
+            if ((index + 1) % 3 === 0 && index + 1 < array.length) {
+              return `,${element}`;
+            }
+            return element;
+          })
+          .reverse()
+          .join('')}원`}
+      </span>
+    </>
+  );
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,11 @@
+const money = [
+  { won: 10, num: 0 },
+  { won: 50, num: 1 },
+  { won: 100, num: 5 },
+  { won: 500, num: 5 },
+  { won: 1000, num: 2 },
+  { won: 5000, num: 2 },
+  { won: 10000, num: 1 },
+];
+
+export default money;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,12 +1,4 @@
-const money = [
-  { won: 10, num: 0 },
-  { won: 50, num: 1 },
-  { won: 100, num: 5 },
-  { won: 500, num: 5 },
-  { won: 1000, num: 2 },
-  { won: 5000, num: 2 },
-  { won: 10000, num: 1 },
-];
+import React from 'react';
 
 const items = [
   { title: '콜라', price: 500 },
@@ -30,5 +22,4 @@ const items = [
   { title: '감자칩', price: 2000 },
   { title: '칸쵸', price: 1000 },
 ];
-
-export { money, items };
+export default items;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -8,4 +8,27 @@ const money = [
   { won: 10000, num: 1 },
 ];
 
-export default money;
+const items = [
+  { title: '콜라', price: 500 },
+  { title: '사이다', price: 1000 },
+  { title: '파인애플 환타', price: 400 },
+  { title: '포도 환타', price: 300 },
+  { title: '레몬에이드', price: 900 },
+  { title: '봉봉', price: 1200 },
+  { title: '코코아', price: 1000 },
+  { title: '제로 콜라', price: 1000 },
+  { title: '파워에이드', price: 2000 },
+  { title: '초코우유', price: 1000 },
+  { title: '초코우유2', price: 7000 },
+  { title: '초코우유3', price: 600 },
+  { title: '딸바주스', price: 1000 },
+  { title: '바나나우유', price: 500 },
+  { title: '커피우유', price: 1000 },
+  { title: '알로에', price: 1200 },
+  { title: '콘칩', price: 1000 },
+  { title: '새우깡', price: 1000 },
+  { title: '감자칩', price: 2000 },
+  { title: '칸쵸', price: 1000 },
+];
+
+export { money, items };

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const items = [
   { title: '콜라', price: 500 },
   { title: '사이다', price: 1000 },


### PR DESCRIPTION
늦어서 죄송합니다! upstream을 rebase하고 cherry pick하는 과정에서 문제가 있어서 이제 올립니다.

## 진행 상황

- [x] context api 적용
- [x] 지갑에서 클릭한 금액이 자판기 input값과 현황판에 적용
- [x]  현황판에서 투입금액, 상품 선택, 잔돈에 관한 정보 출력

https://user-images.githubusercontent.com/58525009/168234304-1b5d0618-1088-43f8-8c65-db03b6bd19f8.mp4

## 고민하는 사항

- [ ] useMemo, React.memo의 차이를 몰라서 공부해야합니다.
- [ ] useReducer의 필요성을 느끼지 못하여 공부가 필요합니다.
- [ ] 리렌더링 최적화가 아직 이뤄지지 못하여서 공부후에 적용하고자 합니다.
- [ ] 거의 모든 상태가 전역상태가 되어서 전역 상태를 최소화하는 방식을 고민하여 적용합니다.
- [ ] Provider 구조가 비슷한데 재활용할 수 있지 않을까?